### PR TITLE
Custom scroll behavior

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="app-container">
     <app-toolbar></app-toolbar>
-    <div class="page-content-container">
+    <div class="page-content-container" cdkScrollable>
         <router-outlet></router-outlet>
     </div>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { PartsEditorModule } from './parts-editor/part-editor.module';
 import { SharedModule } from './shared/shared.module';
 import { ToolbarModule } from './toolbar/toolbar.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 
 @NgModule({
   declarations: [AppComponent],
@@ -22,6 +23,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     PartsEditorModule,
     AppRoutingModule,
     ToolbarModule,
+    ScrollingModule
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/grid/directives/grid-cell.directive.ts
+++ b/src/app/grid/directives/grid-cell.directive.ts
@@ -1,4 +1,6 @@
+import { CdkScrollable } from '@angular/cdk/scrolling';
 import { CdkColumnDef } from '@angular/cdk/table';
+import { DOCUMENT } from '@angular/common';
 import {
   AfterViewInit,
   ContentChild,
@@ -15,6 +17,7 @@ import { Subject, takeUntil } from 'rxjs';
 import { GridCellValueComponent } from '../components/grid-cell-value/grid-cell-value.component';
 import { AriaGrid, ARIA_GRID } from '../models/aria-grid';
 import { Foscusable } from '../models/editable';
+import { Direction, PlaneDirection, Point } from '../utils/point';
 
 @Directive({
   selector: 'td[appGridCell]',
@@ -29,6 +32,8 @@ export class GridCellDirective
     @Inject(ARIA_GRID) private grid: AriaGrid,
     private elementRef: ElementRef,
     private render2: Renderer2,
+    @Inject(DOCUMENT) private document: Document,
+    @Optional() private scrollableContainer: CdkScrollable,
     @Optional() private cdkColumnDef: CdkColumnDef
   ) {}
 
@@ -45,6 +50,10 @@ export class GridCellDirective
 
   get nativeElement(): HTMLTableCellElement {
     return this.elementRef.nativeElement as HTMLTableCellElement;
+  }
+
+  get boundingRect(): DOMRect {
+    return this.nativeElement.getBoundingClientRect();
   }
 
   set selectionSource(value: boolean) {
@@ -80,12 +89,138 @@ export class GridCellDirective
     this.destroy$.next();
   }
 
-  focus() {
-    this.nativeElement.focus();
+  focus(cursorDirection?: PlaneDirection) {
+    this.nativeElement.focus({ preventScroll: true });
+    this.scrollIntoView(cursorDirection);
     this.render2.setAttribute(this.nativeElement, 'tabindex', '0');
   }
 
   focusOut() {
     this.render2.setAttribute(this.nativeElement, 'tabindex', '-1');
+  }
+
+  scrollIntoView(cursorDirection?: PlaneDirection) {
+    this.nativeElement.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+    this.scrollPastCover(cursorDirection);
+  }
+
+  private scrollPastCover(
+    cursorDirection?: PlaneDirection,
+    maxScrollIterations = 1
+  ) {
+    const scrollDirection = {
+      x: cursorDirection?.x !== 0 ? this.getHorizontalScrollDirection() : 0,
+      y: cursorDirection?.y !== 0 ? this.getVerticalScrollDirection() : 0,
+    };
+
+    let cover = this.getElementCover(scrollDirection);
+    let iteration = 0;
+
+    while (cover !== null && iteration < maxScrollIterations) {
+      const offset = this.getScrollOffset(cover, scrollDirection);
+      this.scrollableContainer
+        .getElementRef()
+        .nativeElement.scrollBy({ left: offset.x, top: offset.y });
+      //cover = this.getElementCover(scrollDirection);
+      iteration++;
+    }
+  }
+
+  private getElementCover(scrollDirections: PlaneDirection): Element | null {
+    const conteinerEl = this.scrollableContainer.getElementRef().nativeElement;
+
+    const rect = this.nativeElement.getBoundingClientRect();
+
+    // Cells in  table are overlapped, meaning a cell will share its top, left corner iwth right bottom corner of the other one
+    const point = {
+      x: scrollDirections.x <= 0 ? rect.left : rect.right - 1,
+      y: scrollDirections.y <= 0 ? rect.top : rect.bottom - 1,
+    } as Point;
+
+    console.log(`scrollDirections: ${JSON.stringify(scrollDirections)}`);
+    // const topElement = this.document.elementFromPoint(
+    //   Math.min(
+    //     Math.max(point.x, conteinerEl.getBoundingClientRect().left),
+    //     conteinerEl.getBoundingClientRect().right
+    //   ),
+    //   Math.min(
+    //     Math.max(point.y, conteinerEl.getBoundingClientRect().top),
+    //     conteinerEl.getBoundingClientRect().bottom
+    //   )
+    // );
+
+    const topElement = this.document.elementFromPoint(point.x, point.y);
+
+    if (
+      this.nativeElement.isSameNode(topElement) ||
+      this.nativeElement.contains(topElement) ||
+      topElement?.contains(this.nativeElement)
+    ) {
+      return null;
+    }
+
+    console.log(topElement);
+    return topElement;
+  }
+
+  private getScrollOffset(
+    coverElement: Element,
+    scrollDirections: PlaneDirection
+  ): Point {
+    const coverRect = coverElement.getBoundingClientRect();
+
+    const scrollOffset = {
+      x:
+        scrollDirections.x <= 0
+          ? (coverRect.right - this.boundingRect.left)
+          : (this.boundingRect.right - coverRect.left),
+      y:
+        scrollDirections.y <= 0
+          ? coverRect.bottom - this.boundingRect.top
+          : this.boundingRect.bottom - coverRect.top,
+    };
+
+    scrollOffset.x *= scrollDirections.x;
+    scrollOffset.y *= scrollDirections.y;
+    console.log(`scroll offset: ${JSON.stringify(scrollOffset)}`);
+
+    return scrollOffset;
+  }
+
+  private getHorizontalScrollDirection(): Direction {
+    const rect = this.nativeElement.getBoundingClientRect();
+
+    const screenCenter = {
+      x: this.document.documentElement.clientHeight / 2,
+      y: this.document.documentElement.clientWidth / 2,
+    } as Point;
+
+    if (rect.left < screenCenter.x) {
+      return -1;
+    }
+
+    if (rect.right > screenCenter.x) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private getVerticalScrollDirection(): Direction {
+    const rect = this.nativeElement.getBoundingClientRect();
+    const screenCenter = {
+      x: this.document.documentElement.clientHeight / 2,
+      y: this.document.documentElement.clientWidth / 2,
+    } as Point;
+
+    if (rect.top < screenCenter.y) {
+      return -1;
+    }
+
+    if (rect.bottom > screenCenter.y) {
+      return 1;
+    }
+
+    return 0;
   }
 }

--- a/src/app/grid/models/cover-report.ts
+++ b/src/app/grid/models/cover-report.ts
@@ -1,0 +1,44 @@
+export interface CoverDetails {
+  leftTop: Element | null;
+  leftBottom: Element | null;
+  rightTop: Element | null;
+  rightBottom: Element | null;
+}
+
+export class CoverReport implements CoverDetails {
+  readonly leftTop: Element;
+  readonly leftBottom: Element;
+  readonly rightTop: Element;
+  readonly rightBottom: Element;
+
+  constructor(covers: CoverDetails) {
+    this.leftTop = covers.leftTop;
+    this.leftBottom = covers.leftBottom;
+    this.rightTop = covers.rightBottom;
+    this.rightBottom = covers.rightBottom;
+  }
+
+  get leftCovered(): boolean {
+    return (
+      this.leftTop && this.leftBottom && !this.rightTop && !this.rightBottom
+    );
+  }
+
+  get rightCovered(): boolean {
+    return (
+      this.rightTop && this.rightBottom && !this.leftTop && !this.leftBottom
+    );
+  }
+
+  get topCovered() {
+    return (
+      this.rightTop && this.leftTop && !this.rightBottom && !this.leftBottom
+    );
+  }
+
+  get bottomCovered() {
+    return (
+      this.rightBottom && this.leftBottom && !this.rightTop && !this.leftTop
+    );
+  }
+}

--- a/src/app/grid/models/editable.ts
+++ b/src/app/grid/models/editable.ts
@@ -1,3 +1,5 @@
+import { PlaneDirection } from '../utils/point';
+
 export interface Editable {
   editMode: boolean;
   edit(key?: string): void;
@@ -5,6 +7,6 @@ export interface Editable {
 
 export interface Foscusable {
   value: Editable;
-  focus(): void;
+  focus(cursorDirection?: PlaneDirection): void;
   focusOut(): void;
 }

--- a/src/app/grid/models/grid-data-source.ts
+++ b/src/app/grid/models/grid-data-source.ts
@@ -12,7 +12,7 @@ export class GridDataSource<T> extends DataSource<T> {
 
   /** Connect function called by the table to retrieve one stream containing the data to render. */
   connect(): Observable<T[]> {
-    return this.data;
+    return this.data.asObservable();
   }
 
   disconnect() {}

--- a/src/app/grid/services/scroll-manager.service.spec.ts
+++ b/src/app/grid/services/scroll-manager.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ScrollManagerService } from './scroll-manager.service';
+
+describe('ScrollManagerService', () => {
+  let service: ScrollManagerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ScrollManagerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/grid/services/scroll-manager.service.ts
+++ b/src/app/grid/services/scroll-manager.service.ts
@@ -19,6 +19,7 @@ interface ScrollOptions {
 export class ScrollManagerService {
   static OVERLAP_MARGIN = 2;
   private elementRect: DOMRect;
+  private containerRect: DOMRect;
 
   constructor(
     @Inject(DOCUMENT) private document: Document,
@@ -38,6 +39,10 @@ export class ScrollManagerService {
   }
 
   scrollPastCover(cursorDirection?: PlaneDirection, maxScrollIterations = 10) {
+    this.containerRect = this.scrollableContainer
+      .getElementRef()
+      .nativeElement.getBoundingClientRect();
+
     let iteration = 0;
 
     do {
@@ -59,13 +64,17 @@ export class ScrollManagerService {
   }
 
   private getElementCover(point?: Point): Element | null {
-    const containerRect = this.scrollableContainer
-      .getElementRef()
-      .nativeElement.getBoundingClientRect();
-
     const topElement = this.document.elementFromPoint(
-      MathUtils.clamp(point.x, containerRect.left + 1, containerRect.right - 1),
-      MathUtils.clamp(point.y, containerRect.top + 1, containerRect.bottom - 1)
+      MathUtils.clamp(
+        point.x,
+        this.containerRect.left + 1,
+        this.containerRect.right - 1
+      ),
+      MathUtils.clamp(
+        point.y,
+        this.containerRect.top + 1,
+        this.containerRect.bottom - 1
+      )
     );
 
     if (

--- a/src/app/grid/services/scroll-manager.service.ts
+++ b/src/app/grid/services/scroll-manager.service.ts
@@ -17,6 +17,7 @@ interface ScrollOptions {
 
 @Injectable()
 export class ScrollManagerService {
+  static OVERLAP_MARGIN = 2;
   private elementRect: DOMRect;
 
   constructor(
@@ -151,15 +152,23 @@ export class ScrollManagerService {
       }),
       leftBottom: this.getElementCover({
         x: this.elementRect.left,
-        y: Math.floor(this.elementRect.bottom - 1),
+        y: Math.floor(
+          this.elementRect.bottom - ScrollManagerService.OVERLAP_MARGIN
+        ),
       }),
       rightTop: this.getElementCover({
-        x: Math.floor(this.elementRect.right - 1),
+        x: Math.floor(
+          this.elementRect.right - ScrollManagerService.OVERLAP_MARGIN
+        ),
         y: this.elementRect.top,
       }),
       rightBottom: this.getElementCover({
-        x: Math.floor(this.elementRect.right - 1),
-        y: Math.floor(this.elementRect.bottom - 1),
+        x: Math.floor(
+          this.elementRect.right - ScrollManagerService.OVERLAP_MARGIN
+        ),
+        y: Math.floor(
+          this.elementRect.bottom - ScrollManagerService.OVERLAP_MARGIN
+        ),
       }),
     });
   }

--- a/src/app/grid/services/scroll-manager.service.ts
+++ b/src/app/grid/services/scroll-manager.service.ts
@@ -1,0 +1,213 @@
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { ElementRef, Inject, Injectable } from '@angular/core';
+import {
+  HorizontalDirection,
+  PlaneDirection,
+  Point,
+  VerticalDirection,
+} from '../utils/point';
+import { CoverReport } from '../models/cover-report';
+import { MathUtils } from '../../shared/utils/math-utils';
+import { DOCUMENT } from '@angular/common';
+
+interface ScrollOptions {
+  coverElement: Element;
+  scrollDirection: PlaneDirection;
+}
+
+@Injectable()
+export class ScrollManagerService {
+  private elementRect: DOMRect;
+
+  constructor(
+    @Inject(DOCUMENT) private document: Document,
+    private scrollableContainer: CdkScrollable,
+    private elementRef: ElementRef
+  ) {}
+
+  private get nativeElement() {
+    return this.elementRef.nativeElement;
+  }
+
+  scrollIntoView(cursorDirection?: PlaneDirection) {
+    this.nativeElement.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+    if (cursorDirection) {
+      this.scrollPastCover(cursorDirection);
+    }
+  }
+
+  scrollPastCover(cursorDirection?: PlaneDirection, maxScrollIterations = 10) {
+    let iteration = 0;
+
+    do {
+      this.elementRect = this.nativeElement.getBoundingClientRect();
+      const scrollOptions = this.getScrollOptions(cursorDirection);
+
+      if (!scrollOptions.coverElement) {
+        break;
+      }
+
+      const offset = this.getScrollOffset(scrollOptions);
+
+      this.scrollableContainer
+        .getElementRef()
+        .nativeElement.scrollBy({ left: offset.x, top: offset.y });
+
+      iteration++;
+    } while (iteration < maxScrollIterations);
+  }
+
+  private getElementCover(point?: Point): Element | null {
+    const containerRect = this.scrollableContainer
+      .getElementRef()
+      .nativeElement.getBoundingClientRect();
+
+    const topElement = this.document.elementFromPoint(
+      MathUtils.clamp(point.x, containerRect.left + 1, containerRect.right - 1),
+      MathUtils.clamp(point.y, containerRect.top + 1, containerRect.bottom - 1)
+    );
+
+    if (
+      this.nativeElement.isSameNode(topElement) ||
+      this.nativeElement.contains(topElement) ||
+      topElement?.contains(this.nativeElement)
+    ) {
+      return null;
+    }
+
+    return topElement;
+  }
+
+  private getScrollDirections(cursorDirection: PlaneDirection): PlaneDirection {
+    const screenCenter = {
+      x: this.document.documentElement.clientHeight / 2,
+      y: this.document.documentElement.clientWidth / 2,
+    } as Point;
+
+    return {
+      x:
+        Math.abs(cursorDirection.x) *
+        this.getHorizontalScrollDirection(screenCenter),
+      y:
+        Math.abs(cursorDirection.y) *
+        this.getVerticalScrollDirection(screenCenter),
+    };
+  }
+
+  private getHorizontalScrollDirection(
+    screenCenter: Point
+  ): HorizontalDirection {
+    if (this.elementRect.left < screenCenter.x) {
+      return HorizontalDirection.left;
+    }
+
+    if (this.elementRect.right > screenCenter.x) {
+      return HorizontalDirection.right;
+    }
+
+    return HorizontalDirection.none;
+  }
+
+  private getVerticalScrollDirection(screenCenter: Point): VerticalDirection {
+    if (this.elementRect.top < screenCenter.y) {
+      return VerticalDirection.up;
+    }
+
+    if (this.elementRect.bottom > screenCenter.y) {
+      return VerticalDirection.down;
+    }
+
+    return VerticalDirection.none;
+  }
+
+  private getScrollOffset({
+    scrollDirection,
+    coverElement,
+  }: ScrollOptions): Point {
+    const coverElementRect = coverElement.getBoundingClientRect();
+
+    const scrollOffset = {
+      x:
+        scrollDirection.x <= 0
+          ? coverElementRect.right - this.elementRect.left
+          : this.elementRect.right - coverElementRect.left,
+      y:
+        scrollDirection.y <= 0
+          ? coverElementRect.bottom - this.elementRect.top
+          : this.elementRect.bottom - coverElementRect.top,
+    };
+
+    scrollOffset.x = Math.ceil(scrollOffset.x) * scrollDirection.x;
+    scrollOffset.y = Math.ceil(scrollOffset.y) * scrollDirection.y;
+
+    return scrollOffset;
+  }
+
+  private getElementCovers(): CoverReport {
+    return new CoverReport({
+      leftTop: this.getElementCover({
+        x: this.elementRect.left,
+        y: this.elementRect.top,
+      }),
+      leftBottom: this.getElementCover({
+        x: this.elementRect.left,
+        y: Math.floor(this.elementRect.bottom - 1),
+      }),
+      rightTop: this.getElementCover({
+        x: Math.floor(this.elementRect.right - 1),
+        y: this.elementRect.top,
+      }),
+      rightBottom: this.getElementCover({
+        x: Math.floor(this.elementRect.right - 1),
+        y: Math.floor(this.elementRect.bottom - 1),
+      }),
+    });
+  }
+
+  private getScrollOptions(cursorDirection: PlaneDirection): ScrollOptions {
+    const coverReport = this.getElementCovers();
+
+    if (coverReport.leftCovered) {
+      return {
+        coverElement: coverReport.leftTop,
+        scrollDirection: {
+          x: HorizontalDirection.left,
+          y: VerticalDirection.none,
+        },
+      };
+    } else if (coverReport.rightCovered) {
+      return {
+        coverElement: coverReport.rightTop,
+        scrollDirection: {
+          x: HorizontalDirection.right,
+          y: VerticalDirection.none,
+        },
+      };
+    } else if (coverReport.topCovered) {
+      return {
+        coverElement: coverReport.leftTop,
+        scrollDirection: {
+          x: HorizontalDirection.none,
+          y: VerticalDirection.down,
+        },
+      };
+    } else if (coverReport.bottomCovered) {
+      return {
+        coverElement: coverReport.leftBottom,
+        scrollDirection: {
+          x: HorizontalDirection.none,
+          y: VerticalDirection.down,
+        },
+      };
+    }
+
+    const scrollDirection = this.getScrollDirections(cursorDirection);
+    const horizontalRef = scrollDirection.x <= 0 ? 'left' : 'right';
+    const vertialRef = scrollDirection.y <= 0 ? 'Top' : 'Bottom';
+
+    return {
+      coverElement: coverReport[horizontalRef + vertialRef],
+      scrollDirection,
+    };
+  }
+}

--- a/src/app/grid/utils/cursor.ts
+++ b/src/app/grid/utils/cursor.ts
@@ -6,7 +6,7 @@ export class Cursor implements Point {
 
   constructor(
     private getBounds: (pos: Point) => Point,
-    private positionChanged: (pos: Point) => void,
+    private positionChanged: (currPos: Point, oldPos: Point) => void,
     private startingPoint: Point = {x: -1, y: -1},
     public wrap = true
   ) {
@@ -22,8 +22,9 @@ export class Cursor implements Point {
   }
 
   set x(xPos: number) {
+    const oldX = this.x;
     this.position.x = normalizeIndex(xPos, this.bounds.x, this.wrap);
-    this.notifyPositionChanged();
+    this.notifyPositionChanged({...this.position, x: oldX});
   }
 
   get y(): number {
@@ -31,13 +32,16 @@ export class Cursor implements Point {
   }
 
   set y(yPos: number) {
+    const oldY = this.y;
+
     this.position.y = normalizeIndex(yPos, this.bounds.y, this.wrap);
-    this.notifyPositionChanged();
+    this.notifyPositionChanged({...this.position, y: oldY});
   }
 
   setPosition(pos: Point) {
+    const oldPos = {...this.position};
     this.position = {...pos};
-    this.notifyPositionChanged();
+    this.notifyPositionChanged(oldPos);
   }
 
   moveUp() {
@@ -76,7 +80,7 @@ export class Cursor implements Point {
     this.position = {...this.startingPoint};
   }
 
-  private notifyPositionChanged() {
-    this.positionChanged({ ...this.position });
+  private notifyPositionChanged(oldPosition: Point) {
+    this.positionChanged({ ...this.position }, oldPosition);
   }
 }

--- a/src/app/grid/utils/grid-key-manager.ts
+++ b/src/app/grid/utils/grid-key-manager.ts
@@ -3,7 +3,7 @@ import { describePressedKey } from '../../shared/utils/keyboard';
 import { GridCursorEvent } from '../models/grid-cursor-event';
 import { Foscusable } from '../models/editable';
 import { Cursor } from './cursor';
-import { Point } from './point';
+import { PlaneDirection, Point } from './point';
 import { hasModifierKey } from '@angular/cdk/keycodes';
 
 export class GridKeyManager<T extends Foscusable> {
@@ -37,7 +37,7 @@ export class GridKeyManager<T extends Foscusable> {
         x: this.cellMatrix?.at(cursor.y).length ?? 0,
         y: this.cellMatrix?.length ?? 0,
       }),
-      (cursor) => this.selectCell(cursor)
+      (currCursor, oldCursor) => this.selectCell(currCursor, oldCursor)
     );
   }
 
@@ -101,16 +101,35 @@ export class GridKeyManager<T extends Foscusable> {
     this.activeItemChanges$.complete();
   }
 
-  private selectCell(cursor: Point) {
+  private selectCell(cursor: Point, oldCursor?: Point) {
     const previousActiveItem = this.activeItem;
     const item = this.getItem(cursor);
 
     if (item && item !== previousActiveItem) {
       this.activeItem?.focusOut();
-      item.focus();
+      item.focus(this.getCursorDirection(cursor, oldCursor));
       this.activeItem = item;
       this.previousActiveItem = previousActiveItem;
       this.activeItemChanges$.next({ position: cursor, item });
     }
+  }
+
+  private getCursorDirection(
+    cursor: Point,
+    oldCursor?: Point
+  ): PlaneDirection | null {
+    if (!oldCursor) {
+      return null;
+    }
+
+    const scrollDirection = {
+      x: cursor.x - oldCursor.x,
+      y: cursor.y - oldCursor.y,
+    };
+
+    scrollDirection.x /= Math.abs(scrollDirection.x || 1);
+    scrollDirection.y /= Math.abs(scrollDirection.y || 1);
+
+    return scrollDirection as PlaneDirection;
   }
 }

--- a/src/app/grid/utils/point.ts
+++ b/src/app/grid/utils/point.ts
@@ -1,4 +1,11 @@
+export type Direction = 1 | -1 | 0;
+
 export interface Point {
   x: number;
   y: number;
+}
+
+export interface PlaneDirection extends Point {
+  x: Direction;
+  y: Direction;
 }

--- a/src/app/grid/utils/point.ts
+++ b/src/app/grid/utils/point.ts
@@ -1,3 +1,15 @@
+export enum VerticalDirection {
+  up = -1,
+  down = 1,
+  none = 0,
+}
+
+export enum HorizontalDirection {
+  left = -1,
+  right = 1,
+  none = 0,
+}
+
 export type Direction = 1 | -1 | 0;
 
 export interface Point {
@@ -6,6 +18,6 @@ export interface Point {
 }
 
 export interface PlaneDirection extends Point {
-  x: Direction;
-  y: Direction;
+  x: HorizontalDirection;
+  y: VerticalDirection;
 }

--- a/src/app/shared/utils/math-utils.ts
+++ b/src/app/shared/utils/math-utils.ts
@@ -1,0 +1,5 @@
+export class MathUtils {
+  static clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+  }
+}


### PR DESCRIPTION
Implement custom scroll behavior for editor worksheet.  When scrolling a cell is inspected in terms of covering elements. If some absolutely positioned elements are obstructing the cell position it is moved in the direction of the screen center. The process is repeated until cell is fully visible or the iteration limit is reached.